### PR TITLE
Add GitHub actions

### DIFF
--- a/.github/workflows/extension.yml
+++ b/.github/workflows/extension.yml
@@ -1,0 +1,25 @@
+name: Create a new version of extension
+
+on:
+  release:
+    types: [created]
+
+jobs:
+  build:
+    name: Build and upload the extension archive
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set env
+        run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
+      - name: Create zip with the new version of extension
+        run: |
+          sed -i "s/RELEASE_VERSION/$RELEASE_VERSION/" manifest.json
+          zip labelsync-$RELEASE_VERSION.zip -@ < extension.files
+      - name: Upload zip to release
+        uses: svenstaro/upload-release-action@v2
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          file: labelsync-${{ env.RELEASE_VERSION }}.zip
+          asset_name: labelsync-${{ env.RELEASE_VERSION }}.zip
+          tag: ${{ github.ref }}

--- a/README.md
+++ b/README.md
@@ -21,5 +21,7 @@ After installing the extension, follow these steps to integrate it with GitHub:
 ## Contribution
 Your contributions are welcome! If you have any improvements or new features to propose, feel free to submit a pull request. We appreciate your help in making this extension better.
 
+If you are adding or removing some file from the extension, please make sure you update file `extension.files` 
+
 ## License
 MIT © [Lerpal](https://lerpal.com/)

--- a/extension.files
+++ b/extension.files
@@ -1,0 +1,10 @@
+content.js
+icon128.png
+jquery-3.7.1.min.js
+LICENSE
+manifest.json
+options.css
+options.html
+options.js
+README.md
+styles.css

--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
     "name": "GitHub LabelSync for JIRA",
-    "version": "1.0.1",
+    "version": "RELEASE_VERSION",
     "description": "This extension adds GitHub labels from associated Pull Requests to JIRA cards, providing essential insights at a glance",
     "manifest_version": 3,
     "content_scripts": [{


### PR DESCRIPTION
Add GitHub workflow and actions to automatically create the extension file when a new release is created.

I've added `extension.yml` workflow, which extracts release version and updates `manifest.json`. After that, it creates an archive with the extension files from `extension.files`.